### PR TITLE
 fix some flaky tests

### DIFF
--- a/dmestore-service/src/main/java/com/huawei/dmestore/services/DmeAccessServiceImpl.java
+++ b/dmestore-service/src/main/java/com/huawei/dmestore/services/DmeAccessServiceImpl.java
@@ -32,6 +32,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -258,7 +259,7 @@ public class DmeAccessServiceImpl implements DmeAccessService {
         dmeToken = null;
         if (params != null && params.get(DmeConstants.HOSTIP) != null) {
             HttpHeaders headers = getHeaders();
-            Map<String, Object> requestbody = new HashMap<>(DmeConstants.COLLECTION_CAPACITY_16);
+            Map<String, Object> requestbody = new LinkedHashMap<>(DmeConstants.COLLECTION_CAPACITY_16);
             requestbody.put("grantType", PASSWORD);
             requestbody.put(USER_NAME, params.get(USER_NAME));
             requestbody.put("value", params.get(PASSWORD));
@@ -488,11 +489,11 @@ public class DmeAccessServiceImpl implements DmeAccessService {
                 // 得到主机的hba信息
                 Map<String, Object> hbamap = vcsdkUtils.getHbaByHostObjectId(ToolUtils.getStr(params.get("hostId")));
                 List<Map<String, Object>> initiators = new ArrayList<>();
-                Map<String, Object> initiator = new HashMap<>(DmeConstants.COLLECTION_CAPACITY_16);
+                Map<String, Object> initiator = new LinkedHashMap<>(DmeConstants.COLLECTION_CAPACITY_16);
                 initiator.put(PROTOCOL, ToolUtils.getStr(hbamap.get(TYPE_FIELD)));
                 initiator.put(PORT_NAME, ToolUtils.getStr(hbamap.get(NAME_FIELD)));
                 initiators.add(initiator);
-                Map<String, Object> requestbody = new HashMap<>(DmeConstants.COLLECTION_CAPACITY_16);
+                Map<String, Object> requestbody = new LinkedHashMap<>(DmeConstants.COLLECTION_CAPACITY_16);
                 requestbody.put(ACCESS_MODE_FIELD, "NONE");
                 requestbody.put(TYPE_FIELD, "VMWAREESX");
                 requestbody.put(IP_FIELD, params.get("host"));
@@ -527,7 +528,7 @@ public class DmeAccessServiceImpl implements DmeAccessService {
             if (params != null && params.get(DmeConstants.CLUSTER) != null
                 && params.get(DmeConstants.HOSTIDS) != null) {
                 // 判断该集群下有多少主机，如果主机在DME不存在就需要创建
-                requestbody = new HashMap<>(DmeConstants.COLLECTION_CAPACITY_16);
+                requestbody = new LinkedHashMap<>(DmeConstants.COLLECTION_CAPACITY_16);
                 requestbody.put(NAME_FIELD, params.get("cluster").toString());
                 requestbody.put("host_ids", params.get("hostids"));
 

--- a/dmestore-service/src/test/java/com/huawei/dmestore/services/DmeAccessServiceImplTest.java
+++ b/dmestore-service/src/test/java/com/huawei/dmestore/services/DmeAccessServiceImplTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -111,7 +112,7 @@ public class DmeAccessServiceImplTest {
         params.put("hostIp", hostIp);
         params.put("hostPort", hostPort);
         HttpHeaders headers = getHeaders(null);
-        Map<String, Object> requestbody = new HashMap<>(16);
+        Map<String, Object> requestbody = new LinkedHashMap<>(16);
         requestbody.put("grantType", "password");
         requestbody.put("userName", userName);
         requestbody.put("value", password);
@@ -304,13 +305,13 @@ public class DmeAccessServiceImplTest {
         hbamap.put("name", "tes");
         when(vcsdkUtils.getHbaByHostObjectId(hostId)).thenReturn(hbamap);
 
-        Map requestbody = new HashMap<>(16);
+        Map requestbody = new LinkedHashMap<>(16);
         requestbody.put("access_mode", "NONE");
         requestbody.put("type", "VMWAREESX");
         requestbody.put("ip", host);
         requestbody.put("host_name", host);
         List<Map<String, Object>> initiators = new ArrayList<>();
-        Map<String, Object> initiator = new HashMap<>(16);
+        Map<String, Object> initiator = new LinkedHashMap<>(16);
         initiator.put("protocol", hbamap.get("type"));
         initiator.put("port_name", hbamap.get("name"));
         initiators.add(initiator);
@@ -336,7 +337,7 @@ public class DmeAccessServiceImplTest {
     public void testCreateHostGroup() throws Exception {
         String hostId = "1456";
         String host = "10.143.132.17";
-        Map requestbody = new HashMap<>(16);
+        Map requestbody = new LinkedHashMap<>(16);
         requestbody.put("name", host);
         requestbody.put("host_ids", hostId);
         Map<String, Object> params = new HashMap<>(16);


### PR DESCRIPTION
 **Description** 
Hi, I'm from a research group of University of Illinois at Urbana-Champaign, focusing on detecting and fixing flaky tests for Java projects.

More than 10 tests in `com.huawei.dmestore.services.DmeAccessServiceImplTest` may fail due to the non-deterministic order of iteration of `HashMap`. Specifically, the `toJson()` used to convert the `HashMap requestbody` into a `JSONString` will iterate the `HashMap` not necessarily in the order of that of putting elements. 
One can check the problem using [NonDex](https://github.com/TestingResearchIllinois/NonDex) :
```
mvn install -pl dmestore-service -am -DskipTests
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl dmestore-service -Dtest=com.huawei.dmestore.services.DmeAccessServiceImplTest
```

**Solution**
Use `LinkedHashMap` instead of `HashMap` when initializing the variable `requestbody` so that it can be converted into a `JSONString` as desired. 
